### PR TITLE
Remove extra parentheses to fix a warning

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -26,7 +26,7 @@
 //! fn fib(n: usize) -> BigUint {
 //!     let mut f0: BigUint = Zero::zero();
 //!     let mut f1: BigUint = One::one();
-//!     for _ in (0..n) {
+//!     for _ in 0..n {
 //!         let f2 = f0 + &f1;
 //!         // This is a low cost way of swapping f0 with f1 and f1 with f2.
 //!         f0 = replace(&mut f1, f2);
@@ -1633,7 +1633,7 @@ impl<R: Rng> RandBigInt for R {
     fn gen_biguint(&mut self, bit_size: usize) -> BigUint {
         let (digits, rem) = bit_size.div_rem(&big_digit::BITS);
         let mut data = Vec::with_capacity(digits+1);
-        for _ in (0 .. digits) {
+        for _ in 0 .. digits {
             data.push(self.gen());
         }
         if rem > 0 {


### PR DESCRIPTION
Removing extra parentheses in a for loop fixes this warning:

src/bigint.rs:1636:18: 1636:31 warning: unnecessary parentheses around `for` head expression, #[warn(unused_parens)] on by default